### PR TITLE
Update for WordPress 6.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,17 @@
 # Change log
 
-## [1.3.2](https://github.com/lightspeeddevelopment/lsx-blocks/releases/tag/1.3.2) - In Development
+## [1.3.3](https://github.com/lightspeeddevelopment/lsx-blocks/releases/tag/1.3.3) - 2023-08-09
+
+### Security
+- General testing to ensure compatibility with latest WordPress version (6.3).
+
+## [1.3.2](https://github.com/lightspeeddevelopment/lsx-blocks/releases/tag/1.3.2) - 2023-04-20
 
 ### Added
 - Added in the Block transformation for the LSX Container block to a Group Block.
+
+### Security
+- General testing to ensure compatibility with latest WordPress version (6.2).
 
 ## [1.3.1](https://github.com/lightspeeddevelopment/lsx-blocks/releases/tag/1.3.1) - 27-05-2022
 

--- a/lsx-blocks.php
+++ b/lsx-blocks.php
@@ -5,14 +5,14 @@
  * Description: The LSX Blocks plugin gives you a collection of Gutenberg blocks that you can use and customize. All the blocks are built to work with our powerful LSX theme.
  * Author: LightSpeed
  * Author URI: https://www.lsdev.biz/
- * Version: 2.0.0
+ * Version: 1.3.3
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * @package LSX BLOCKS
  */
 
-define( 'LSX_BLOCKS_VER', '2.0.0' );
+define( 'LSX_BLOCKS_VER', '1.3.3' );
 define( 'LSX_BLOCKS_PATH', plugin_dir_path( __FILE__ ) );
 define( 'LSX_BLOCKS_CORE', __FILE__ );
 define( 'LSX_BLOCKS_URL', plugin_dir_url( __FILE__ ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lsx-blocks",
-	"version": "1.3.1",
+	"version": "1.3.3",
 	"private": true,
 	"scripts": {
 		"build-blocks": "wp-scripts build src/blocks.js --output-path=dist"

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: feedmymedia, lightspeedwp, eleshar, krugazul, jacquesvdh, ignusver
 Donate link: https://lsdev.biz/lsx/donate/
 Tags: lsx, blocks, gutenberg, block editor, page builder, wordpress blocks
 Requires at least: 5.0
-Tested up to: 6.0
-Requires PHP: 8.0
-Stable tag: 1.3.1
+Tested up to: 6.3
+Requires PHP: 7.4
+Stable tag: 1.3.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 


### PR DESCRIPTION
### Description
- General testing to ensure compatibility with latest WordPress version (6.3).
- Updating the version number and stable tag